### PR TITLE
Refactor - Editor Part 2 - Cache Paints

### DIFF
--- a/src/Feature/Editor/GutterView.re
+++ b/src/Feature/Editor/GutterView.re
@@ -9,6 +9,10 @@ module Constants = {
   let gutterMargin = 3.;
 };
 
+let lineNumberPaint = Skia.Paint.make();
+Skia.Paint.setTextEncoding(lineNumberPaint, Utf8);
+Skia.Paint.setAntiAlias(lineNumberPaint, true);
+Skia.Paint.setLcdRenderText(lineNumberPaint, true);
 let renderLineNumber =
     (
       ~context: Draw.context,
@@ -45,11 +49,8 @@ let renderLineNumber =
     isActiveLine
       ? theme.editorActiveLineNumberForeground
       : theme.editorLineNumberForeground;
-  let paint = Skia.Paint.make();
+  let paint = lineNumberPaint;
   Skia.Paint.setColor(paint, Revery.Color.toSkia(lineNumberTextColor));
-  Skia.Paint.setTextEncoding(paint, Utf8);
-  Skia.Paint.setAntiAlias(paint, true);
-  Skia.Paint.setLcdRenderText(paint, true);
   Skia.Paint.setTextSize(paint, context.fontSize);
   Skia.Paint.setTypeface(paint, Revery.Font.getSkiaTypeface(context.font));
 


### PR DESCRIPTION
I think this is a pretty simple, low-impact change (called out in the description of the PR too) - to cache the paint objects.

Comparing the allocation profile for the 'Editor Surface - 1000 lines' benchmark across the branches:

| Branch | Minor Alloc | Promoted Alloc | Major Alloc |
| --- | --- | --- | --- |
| `master` | 8833340 | 84282 | 2162602 |
| `refactor/editor/part-2` - w/ paint caching (this PR) | 8910226 (<1% increase) | 85603 (2% increase) | 2163923 (<1% increase) |
| `refactor/editor/part-2` - no caching | 9027766 (~2% increase) | 203143 (__~140% increase__) | 2281463 (~5% increase) |

The paint caching brings us pretty close to what we had in master - especially for the promoted words. The promoted words are the words that survive a minor collection (which is usually pretty fast) and get put on the major heap (which is slower). 